### PR TITLE
Fix hang on Linux

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-warnings=ExperimentalWarning
+#!/usr/bin/env -S node --no-warnings=ExperimentalWarning
 
 import { Command, Option } from "commander";
 import path from "path";


### PR DESCRIPTION
When invoking `gpt-po` as an executable, it will not currently work on Linux (hangs indefinitely). This is because the shebang line attempts to pass a flag to `node`.

```
#!/usr/bin/env node --no-warnings=ExperimentalWarning
```

By default, the `#!/usr/bin/env` will treat anything following it as a single argument, so it tries to invoke a binary called `"node --no-warnings=ExperimentalWarning"` 

To support passing additional parameters to ‘node’ we need to add the `-S` flag, as described here:
https://stackoverflow.com/questions/62550080/script-with-env-shebang-hangs-on-linux

This isn't needed on macOS, but I don't believe it will cause any problems.