### PR TITLE
Fixes for issue #30

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -92,7 +92,7 @@ export async function translate(
       return `<translate index="${idx + dicts.user.length + 1}"${contextAttr}>${tr.msgid}</translate>`;
     })
     .join("\n");
-
+  
   const res = await _openai.chat.completions.create(
     {
       model: model,
@@ -105,12 +105,12 @@ export async function translate(
         {
           role: "user",
           content:
-            `${_userprompt}\n\nWait for my incoming message in "${src}" and translate it into "${lang}"(a language code and an optional region code). ` +
+            `${_userprompt}\n\nWait for my incoming message(s) in \`${src}\` and translate them into \`${lang}\` (\`${src}\` and \`${lang}\` are XPG/POSIX locale names, used in Unix-like systems and GNU Gettext). ` +
             notes
         },
         {
           role: "assistant",
-          content: `Understood, I will translate your incoming "${src}" message into "${lang}", carefully following guidelines. Please go ahead and send your message for translation.`
+          content: `Understood, I will translate your incoming \`${src}\` message(s) into \`${lang}\`, carefully following guidelines. Please go ahead and send your message(s) for translation.`
         },
         // add userdict
         ...(dicts.user.length > 0

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -92,7 +92,7 @@ export async function translate(
       return `<translate index="${idx + dicts.user.length + 1}"${contextAttr}>${tr.msgid}</translate>`;
     })
     .join("\n");
-  
+
   const res = await _openai.chat.completions.create(
     {
       model: model,

--- a/src/userprompt.txt
+++ b/src/userprompt.txt
@@ -15,7 +15,7 @@ Translation guidelines are as follows:
 4. **Context Handling**:
    - Some messages will include a context attribute in the translate tag, e.g., `<translate index="1" context="Menu">`.
    - Use this context to inform your translation but only return the translated text.
-   - Example:
+   - Example (translating from `en_GB` to `fr_FR`):
      Input: `<translate index="1" context="Menu">File</translate>`
      Output: `<translated index="1">Fichier</translated>`
 
@@ -23,7 +23,7 @@ Translation guidelines are as follows:
    - You may receive multiple translation requests in a single input, each with a unique index.
    - Ensuring the complete number of requests are translated, even if they are repeated, while maintaining the original order when possible.
 
-**Examples**:
+**Example (translating from `en_US` to `zh_CN`):**
 - Input:
   `<translate index="1">This is a message. </translate>`
   `<translate index="2"> Hello %s</translate>`


### PR DESCRIPTION
Resolves ryanhex53/gpt-po#30 

* Clarified the source and dest languages used in the examples in userprompt.txt
* More accurately define the formatting used for locales
* Modified prompt to indicate that multiple messages could be provided for translation
* Enclose locales in backticks, per recommendation from ChatGPT